### PR TITLE
Lookup puppetdb_url in hieradata under data::puppet::puppetdb::url

### DIFF
--- a/manifests/balie.pp
+++ b/manifests/balie.pp
@@ -5,7 +5,7 @@ class deployment::balie (
   $angular_package_version = 'latest',
   $angular_app_deploy_config_source = 'puppet:///modules/deployment/angular/angular-deploy-config.rb',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitpas-balie-frontend']

--- a/manifests/groepspas.pp
+++ b/manifests/groepspas.pp
@@ -2,7 +2,7 @@ class deployment::groepspas (
   $angular_app_config_source,
   $angular_app_deploy_config_source = 'puppet:///modules/deployment/angular/angular-deploy-config.rb',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/uitpas-groepspas-frontend'

--- a/manifests/museumpas.pp
+++ b/manifests/museumpas.pp
@@ -8,7 +8,7 @@ class deployment::museumpas (
   $robots_source      = undef,
   $project_prefix     = 'museumpas',
   $noop_deploy        = false,
-  $puppetdb_url       = undef
+  $puppetdb_url       = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/museumpas'

--- a/manifests/museumpas/website.pp
+++ b/manifests/museumpas/website.pp
@@ -5,7 +5,7 @@ class deployment::museumpas::website (
   $version            = 'latest',
   $robots_source      = undef,
   $noop_deploy        = false,
-  $puppetdb_url       = undef
+  $puppetdb_url       = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/museumpas'

--- a/manifests/newsletter.pp
+++ b/manifests/newsletter.pp
@@ -1,7 +1,7 @@
 class deployment::newsletter (
   $config_source,
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitdatabank-newsletter-api']

--- a/manifests/omd/angular.pp
+++ b/manifests/omd/angular.pp
@@ -3,7 +3,7 @@ class deployment::omd::angular (
   $deploy_config_source = 'puppet:///modules/deployment/angular/angular-deploy-config.rb',
   $project_prefix = 'omd',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain deployment

--- a/manifests/omd/drupal.pp
+++ b/manifests/omd/drupal.pp
@@ -5,7 +5,7 @@ class deployment::omd::drupal (
   $pubkey_source,
   $project_prefix = 'omd',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain deployment

--- a/manifests/omd/mediadownloadmanager.pp
+++ b/manifests/omd/mediadownloadmanager.pp
@@ -2,7 +2,7 @@ class deployment::omd::mediadownloadmanager (
   $config_source,
   $project_prefix = 'omd',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   package { 'omd-media-download-manager':

--- a/manifests/projectaanvraag/angular.pp
+++ b/manifests/projectaanvraag/angular.pp
@@ -3,7 +3,7 @@ class deployment::projectaanvraag::angular (
   $version              = 'latest',
   $deploy_config_source = 'puppet:///modules/deployment/angular/angular-deploy-config.rb',
   $noop_deploy          = false,
-  $puppetdb_url         = undef
+  $puppetdb_url         = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain deployment

--- a/manifests/projectaanvraag/silex.pp
+++ b/manifests/projectaanvraag/silex.pp
@@ -5,7 +5,7 @@ class deployment::projectaanvraag::silex (
   $db_name,
   $version      = 'latest',
   $noop_deploy  = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain deployment

--- a/manifests/udb3/angular/instance.pp
+++ b/manifests/udb3/angular/instance.pp
@@ -4,7 +4,7 @@ define deployment::udb3::angular::instance (
   $lib_package_name,
   $app_rootdir,
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitdatabank-angular-app']

--- a/manifests/udb3/apidoc.pp
+++ b/manifests/udb3/apidoc.pp
@@ -1,7 +1,7 @@
 class deployment::udb3::apidoc (
   $project_prefix = 'udb3',
   $noop_deploy    = false,
-  $puppetdb_url   = undef
+  $puppetdb_url   = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['cultuurnet-udb3']

--- a/manifests/udb3/cdbxml.pp
+++ b/manifests/udb3/cdbxml.pp
@@ -5,7 +5,7 @@ class deployment::udb3::cdbxml (
   $db_name,
   $project_prefix = 'udb3',
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   apt::source { 'cultuurnet-cdbxml':

--- a/manifests/udb3/entry_api.pp
+++ b/manifests/udb3/entry_api.pp
@@ -13,8 +13,8 @@ class deployment::udb3::entry_api (
   $event_conclude_hour         = '0',
   $event_conclude_minute       = '0',
   $noop_deploy                 = false,
-  $puppetdb_url                = undef,
-  $excluded_labels_source      = undef
+  $excluded_labels_source      = undef,
+  $puppetdb_url                = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitdatabank-entry-api']

--- a/manifests/udb3/frontend.pp
+++ b/manifests/udb3/frontend.pp
@@ -6,7 +6,7 @@ class deployment::udb3::frontend (
   String                                  $service_ensure      = 'running',
   Boolean                                 $service_enable      = true,
   Variant[Boolean, Enum['true', 'false']] $noop_deploy         = false,
-  Optional[String]                        $puppetdb_url        = undef
+  Optional[String]                        $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir      = '/var/www/udb3-frontend'

--- a/manifests/udb3/geojson_data.pp
+++ b/manifests/udb3/geojson_data.pp
@@ -1,7 +1,7 @@
 class deployment::udb3::geojson_data (
   $version      = 'latest',
   $noop_deploy  = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitdatabank-geojson-data']

--- a/manifests/udb3/jwt.pp
+++ b/manifests/udb3/jwt.pp
@@ -3,7 +3,7 @@ class deployment::udb3::jwt (
   $privkey_source,
   $pubkey_source,
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/udb3-jwt-provider-uitidv1'

--- a/manifests/udb3/jwtprovider.pp
+++ b/manifests/udb3/jwtprovider.pp
@@ -1,7 +1,7 @@
 class deployment::udb3::jwtprovider (
   $config_source,
   $noop_deploy = false,
-  $puppetdb_url = undef
+  $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/udb3-jwt-provider'

--- a/manifests/udb3/movie_api_fetcher.pp
+++ b/manifests/udb3/movie_api_fetcher.pp
@@ -4,7 +4,7 @@ class deployment::udb3::movie_api_fetcher (
   $kinepolis_theaters_source = 'puppet:///modules/deployment/movie_api_fetcher/kinepolis_theaters.yml',
   $kinepolis_terms_source    = 'puppet:///modules/deployment/movie_api_fetcher/kinepolis_terms.yml',
   $noop_deploy               = false,
-  $puppetdb_url              = undef
+  $puppetdb_url              = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   realize Apt::Source['uitdatabank-movie-api-fetcher']

--- a/manifests/udb3/search.pp
+++ b/manifests/udb3/search.pp
@@ -11,7 +11,7 @@ class deployment::udb3::search (
   $reindex_permanent_minute = '0',
   $region_mapping_source    = 'puppet:///modules/deployment/search/mapping_region.json',
   $noop_deploy              = false,
-  $puppetdb_url             = undef
+  $puppetdb_url             = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/udb3-search-service'

--- a/manifests/uitid.pp
+++ b/manifests/uitid.pp
@@ -25,7 +25,8 @@ class deployment::uitid (
   $auth0_original_domain                 = undef,
   $stackdriver_servicecredentials_source = undef,
   $swagger_base_url                      = undef,
-  $uitalert_use_fast_search              = false
+  $uitalert_use_fast_search              = false,
+  $puppetdb_url                          = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain profiles::glassfish

--- a/manifests/uitpas.pp
+++ b/manifests/uitpas.pp
@@ -23,7 +23,8 @@ class deployment::uitpas (
   $ksb_auth0_clientid      = undef,
   $ksb_auth0_secret        = undef,
   $sysadmin_auth0_clientid = undef,
-  $sysadmin_auth0_secret   = undef
+  $sysadmin_auth0_secret   = undef,
+  $puppetdb_url            = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   contain profiles::glassfish

--- a/manifests/widgetbeheer/angular.pp
+++ b/manifests/widgetbeheer/angular.pp
@@ -3,7 +3,7 @@ class deployment::widgetbeheer::angular (
   $htaccess_source,
   $version          = 'latest',
   $noop_deploy      = false,
-  $puppetdb_url     = undef
+  $puppetdb_url     = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) {
 
   $basedir = '/var/www/widgetbeheer-frontend'


### PR DESCRIPTION
### Changed

- Lookup puppetdb_url in hieradata under data::puppet::puppetdb::url by default,
  to avoid having to specify the parameter on every deployment class

---
Ticket: https://jira.uitdatabank.be/browse/OPS-952